### PR TITLE
Check for null value in Content-Length header

### DIFF
--- a/src/main/java/com/enonic/lib/http/client/HttpRequestHandler.java
+++ b/src/main/java/com/enonic/lib/http/client/HttpRequestHandler.java
@@ -318,10 +318,14 @@ public final class HttpRequestHandler
         {
             this.trace.put( "status", response.code() );
             this.trace.put( "type", response.header( "Content-Type" ) );
-            final Long length = Longs.tryParse( response.header( "Content-Length" ) );
-            if ( length != null )
+            final String contentLength = response.header( "Content-Length" );
+            if ( contentLength != null )
             {
-                this.trace.put( "size", length );
+                final Long length = Longs.tryParse( contentLength );
+                if ( length != null )
+                {
+                    this.trace.put( "size", length );
+                }
             }
         }
     }


### PR DESCRIPTION
I'm a Seeds employee and we have a problem with content-length not set on requests, causing NullPointerException, as shown below:

```
Caused by: java.lang.NullPointerException: null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:210)
        at com.google.common.primitives.Longs.tryParse(Longs.java:337)
        at com.enonic.lib.http.client.HttpRequestHandler.endTracing(HttpRequestHandler.java:321)
        at com.enonic.lib.http.client.HttpRequestHandler.executeRequest(HttpRequestHandler.java:92)
        at com.enonic.xp.trace.Tracer.traceEx(Tracer.java:72)
        at com.enonic.lib.http.client.HttpRequestHandler.request(HttpRequestHandler.java:85)
        at jdk.nashorn.internal.scripts.Script$Recompilation$6722$3226A$http_client.L:1$request(no.seeds.as:/lib/http-client.js:85)
```

PS.: The error was reproduced successfully on servers running apache2 with mod http2 enabled.