### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly "com.enonic.xp:script-api:${xpVersion}"
     compileOnly "com.enonic.xp:core-api:${xpVersion}"
     implementation 'com.github.mizosoft.methanol:methanol:1.7.0'
-    implementation 'io.github.hakky54:sslcontext-kickstart:9.1.0'
+    implementation 'io.github.hakky54:ayza:10.0.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-core:5.19.0"
     testImplementation "com.squareup.okhttp3:okhttp-tls:${okhttpVersion}"


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience