### PR TITLE
Bump version to 4.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "3.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}


### PR DESCRIPTION
## Summary

Master is already at `4.0.0-SNAPSHOT` (XP 8). This PR completes the branch-out by wiring `3.x` (the new XP 7 maintenance branch, created at `fef9130` — the post-`v3.2.2` "Updated to next SNAPSHOT version" commit, so its `gradle.properties` reads `version=3.2.3-SNAPSHOT`) into CI:

- `enonic-gradle.yml` — declare both `master` and `3.x` as release branches via `releaseBranch:`.
- `enonic-docgen.yml` — also build docs on pushes to `3.x`.
- `docs/versions.json` — new file mapping `stable` → `3.x` and `next` → `master` for the developer portal.

`gradle.properties` is **not** touched on master because `version=4.0.0-SNAPSHOT` already matches the next-major SNAPSHOT target.

A companion PR against `3.x` adds the same `releaseBranch:` block to its workflow file (required because the build action reads the workflow from the branch being built).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` on master is green
- [ ] After merge, the next push to `master` is classified as a release branch by the build action

🤖 Generated with [Claude Code](https://claude.com/claude-code)