### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Companion to the master-side bump (#213). The build action reads `releaseBranch:` from the workflow file on the branch being built, so this same list has to land on `3.x` itself for pushes here to be classified as release builds.

Only this one workflow file is changed — no `gradle.properties` bump, no docgen change, no `versions.json` (those are master-only per the app-booster reference).

`gradle.properties` on this branch is intentionally `version=3.2.3-SNAPSHOT` (the post-`v3.2.2` "Updated to next SNAPSHOT version" commit), not `v3.2.2`'s release version, so the release tooling doesn't try to re-release the tag.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next push to `3.x` is classified as a release branch by the build action

🤖 Generated with [Claude Code](https://claude.com/claude-code)