### PR TITLE
Migrate to Gradle version catalog and rename sslcontext-kickstart to ayza

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,29 +2,25 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'maven-publish'
-    id 'com.enonic.defaults' version '2.1.6'
+    alias(libs.plugins.enonic.defaults)
     id 'com.enonic.xp.base'
-}
-
-ext {
-    okhttpVersion = '5.3.2'
 }
 
 dependencies {
     compileOnly xplibs.api.script
     compileOnly xplibs.api.core
-    implementation 'com.github.mizosoft.methanol:methanol:1.9.0'
-    implementation 'io.github.hakky54:sslcontext-kickstart:9.2.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter:6.0.3'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation "org.mockito:mockito-core:5.23.0"
-    testImplementation "com.squareup.okhttp3:okhttp-tls:${okhttpVersion}"
-    testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
+    implementation libs.methanol
+    implementation libs.ayza
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.jupiter.engine
+    testRuntimeOnly libs.junit.platform.launcher
+    testImplementation libs.mockito.core
+    testImplementation libs.okhttp.tls
+    testImplementation libs.okhttp.mockwebserver
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation('org.slf4j:slf4j-api') {
+    testImplementation(libs.slf4j.api) {
         version {
-            strictly '1.7.26'
+            strictly libs.versions.slf4j.get()
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+[versions]
+methanol = "1.9.0"
+ayza = "10.0.5"
+junit5 = "6.0.3"
+mockito = "5.23.0"
+okhttp = "5.3.2"
+slf4j = "1.7.26"
+
+[libraries]
+methanol = { module = "com.github.mizosoft.methanol:methanol", version.ref = "methanol" }
+ayza = { module = "io.github.hakky54:ayza", version.ref = "ayza" }
+
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+
+okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+
+[plugins]
+enonic-defaults = { id = "com.enonic.defaults", version = "2.1.6" }


### PR DESCRIPTION
## Summary

Migrate `build.gradle` to use a Gradle version catalog at `gradle/libs.versions.toml`, matching the convention used in the [xp monorepo](https://github.com/enonic/xp/blob/master/gradle/libs.versions.toml).

- All inline version strings (methanol, junit-jupiter, mockito-core, slf4j-api, okhttp-tls, mockwebserver) are now `libs.xxx` references.
- The `ext { okhttpVersion = '5.3.2' }` block is removed; the shared okhttp version is a single `okhttp` key in the catalog referenced by both `okhttp-tls` and `mockwebserver`.
- The `com.enonic.defaults` plugin moves to the `[plugins]` table and is applied via `alias(libs.plugins.enonic.defaults)`.

## sslcontext-kickstart → ayza rename

`io.github.hakky54:sslcontext-kickstart` was [renamed to `io.github.hakky54:ayza`](https://github.com/Hakky54/ayza/discussions/670) in September 2025 (10.0.0). Bumped from 9.2.1 → **10.0.5**.

The Java package `nl.altindag.ssl.*` is unchanged, so no source edits are required. Reviewed the 9.x → 10.x changelog; the features used by `HttpClientFactory` (`SSLFactory.builder()`, `withTrustMaterial` / `withDefaultTrustMaterial` / `withIdentityMaterial`, `getSslContext`, `getSslParameters`) were not touched in any breaking way.

## Test plan

- [x] `./gradlew build` runs green locally (all tests pass)
- [x] `./gradlew dependencies --configuration runtimeClasspath` confirms `io.github.hakky54:ayza:10.0.5` is on the runtime classpath
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)