### PR TITLE
Align docs structure + drop version clutter #228

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "4.x"
       - "3.x"
     paths:
       - 'docs/**'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,6 +1,6 @@
 = HTTP Client Library
 
-image::https://img.shields.io/badge/xp-7.+-blue.svg[role="right"]
+NOTE: Versions 4.x target XP 8+.
 
 Easily access remote web API's and data sources over HTTP using this library.
 
@@ -9,7 +9,7 @@ To start using this library, add the following into your `build.gradle` file:
 [source,groovy]
 ----
 dependencies {
-  include 'com.enonic.lib:lib-http-client:3.2.1'
+  include "com.enonic.lib:lib-http-client:${libVersion}"
 }
 ----
 
@@ -88,7 +88,7 @@ The request function takes a parameter object with options. The only mandatory o
 ** `*queryParams*` (_object_) Query parameters to be sent with the request.
 ** `*params*` (_object_) Form parameters to be sent with the request. Will not be used if `*queryParams*` is provided.
 ** `*headers*` (_object_) HTTP headers, an object where the keys are header names and the values the header values.
-** `*disableHttp2*` (_boolean_) Disable use of HTTP/2 protocol. The default value is `false`. For insecure HTTP connections HTTP/2 is always disabled. (added in v3.2.0)
+** `*disableHttp2*` (_boolean_) Disable use of HTTP/2 protocol. The default value is `false`. For insecure HTTP connections HTTP/2 is always disabled.
 ** `*connectionTimeout*` (_number_) The timeout on establishing the connection, in milliseconds. The default value is `10000`.
 ** `*readTimeout*` (_number_) The timeout on waiting to receive data, in milliseconds. The default value is `10000`.
 ** `*body*` (_string_ | _object_) Body content to send with the request, usually for POST or PUT requests. It can be of type string or stream.
@@ -120,7 +120,7 @@ The function will return a `response` object with the following properties:
 * `*body*` (_string_) Body of the response as string. Null if the response content-type is not of type text.
 * `*bodyStream*` (_object_) Body of the response as a stream object.
 
-== KeyStore and TrustStore Configuration [*v3.0.0+*]
+== KeyStore and TrustStore Configuration
 
 Use JVM system properties to configure KeyStore and TrustSore:
 https://docs.oracle.com/en/java/javase/11/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-7D9F43B8-AABF-4C5B-93E6-3AFB18B66150
@@ -212,16 +212,4 @@ const response = httpClient.request({
 
 == Compatibility
 
-- This library is not compatible with XP releases before version 7.0. Make sure you reference the lib as `/lib/http-client`
-and not as `/lib/xp/http-client` or `/site/lib/xp/http-client`.
-
-- Starting from version 3.0.0 library Uses Java HttpClient instead of OkHttp Client.
-It may introduce a few minor incompatibilities.
-For instance, Default User-Agent is now JVM vendor dependent.
-
-- Starting from version 3.0.0 library does not support Preemptive authentication.
-Use `Authorization: Basic <credentials>` header instead.
-
-- Starting from version 3.0.0 library uses Java Platform KeyStore.
-It is JVM vendor specific but in most cases it is specified by `javax.net.ssl.keyStore` system property.
-KeyStore Configuration is no longer applicable and `clientCertificate` can only be typeof Stream.
+- Preemptive authentication is not supported. Use an `Authorization: Basic <credentials>` header instead.

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "3.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "4.x", "latest": true },
+    { "label": "3.x", "checkout": "3.x" }
   ]
 }


### PR DESCRIPTION
Closes #228.

Brings `docs/` in line with the reference `enonic/lib-cors` layout and drops "what was added when" clutter from the current (XP 8) docs. The `3.x` (XP 7) branch is left untouched — a separate PR against `4.x` will cherry-pick just the doc cleanup.

## Structure

- `docs/index.adoc`: add `NOTE: Versions 4.x target XP 8+.` near the top.
- `docs/versions.json`: `4.x` becomes `stable` (`latest: true`) with `3.x` as the second entry (drops the pre-release `next / master` pairing).
- `.github/workflows/enonic-docgen.yml`: also trigger on push to `4.x`, matching every branch listed in `versions.json`.

## Clutter removed from `docs/index.adoc`

- `image::…badge/xp-7.+…` — XP 7+ shield no longer reflects the target platform (4.x is XP 8+).
- `include 'com.enonic.lib:lib-http-client:3.2.1'` → `include "com.enonic.lib:lib-http-client:${libVersion}"`. The hardcoded 3.2.1 was frozen from an earlier version; the placeholder mirrors what lib-cors does.
- `(added in v3.2.0)` on the `disableHttp2` option.
- `[*v3.0.0+*]` on the `KeyStore and TrustStore Configuration` section heading.
- Three of four bullets in `== Compatibility`:
  - "Not compatible with XP releases before version 7.0 …" — pre-XP 8 caveat that no longer applies (4.x is XP 8+); `/lib/xp/http-client` isn't a name XP core defines anyway.
  - "Starting from version 3.0.0 library uses Java HttpClient instead of OkHttp …" — describes the 2.x → 3.x transition.
  - "Starting from version 3.0.0 library uses Java Platform KeyStore …" — duplicates the `KeyStore and TrustStore Configuration` section above and describes a removal (`clientCertificate can only be typeof Stream`) that new readers don't need to know about.

## Deliberately kept

- The `Preemptive authentication is not supported. Use an Authorization: Basic <credentials> header instead.` bullet — reworded to current tense (dropped the "Starting from version 3.0.0" prefix). This is a functional caveat readers still hit today, not a changelog note.
- `KeyStore and TrustStore Configuration` section body, including the `WARNING` about `certificates` / `clientCertificate` — current behavior.
- `Compression` section — current behavior.

## Verify

- `docs/versions.json` re-parses as valid JSON.
- `.github/workflows/enonic-docgen.yml` re-parses as valid YAML.
- `docs/index.adoc` renders with `asciidoc` locally (same warnings as lib-cors' `index.adoc` in the same environment — missing `source-highlight` binary, not a doc problem).